### PR TITLE
Link the build badge to the right Travis build.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Control Repository for developer.rackspace.com
 
-[![Build Status](https://travis-ci.org/rackerlabs/nexus-control.svg?branch=master)](https://travis-ci.org/rackerlabs/nexus-control)
+[![Build Status](https://travis-ci.org/j12y/nexus-control.svg?branch=master)](https://travis-ci.org/j12y/nexus-control)
 
 Deconst control repository used to host [developer.rackspace.com](https://developer.rackspace.com/).


### PR DESCRIPTION
Otherwise it'll show the status and link to the rackerlabs fork, which isn't helpful.
