### PR TITLE
add white paper url scheme and templates with download link

### DIFF
--- a/assets/support.rackspace.com/src/css/main.scss
+++ b/assets/support.rackspace.com/src/css/main.scss
@@ -30,7 +30,7 @@ a {
 
 .content {
     margin-left: 0;
-    padding: 20px 0 40px 40px;
+    padding: 35px 0 40px 40px;
     font-family: $font-family-primary;
     color: #474747;
     border-left: 1px solid #ccc;
@@ -47,7 +47,6 @@ a {
     }
     
     h2 {
-        margin: 25px 0 30px;
         font-weight: 400;
         font-size: 28px;
         line-height: 33px;
@@ -652,28 +651,28 @@ a {
             }
         
             .email {
-                background-image: url('../images/icon-email.png');
-                background-image: none, url('../images/icon-email.svg');
+                background-image: url($assets_support_rackspace_com_dist_img_icon_email_png);
+                background-image: none, url($assets_support_rackspace_com_dist_img_icon_email_svg);
             }
         
             .skype {
-                background-image: url('../images/icon-skype.png');
-                background-image: none, url('../images/icon-skype.svg');
+                background-image: url($assets_support_rackspace_com_dist_img_icon_skype_png);
+                background-image: none, url($assets_support_rackspace_com_dist_img_icon_skype_svg);
             }
         
             .exchange {
-                background-image: url('../images/icon-exchange.png');
-                background-image: none, url('../images/icon-exchange.svg');
+                background-image: url($assets_support_rackspace_com_dist_img_icon_exchange_png);
+                background-image: none, url($assets_support_rackspace_com_dist_img_icon_exchange_svg);
             }
         
             .sharepoint {
-                background-image: url('../images/icon-sharepoint.png');
-                background-image: none, url('../images/icon-sharepoint.svg');
+                background-image: url($assets_support_rackspace_com_dist_img_icon_sharepoint_png);
+                background-image: none, url($assets_support_rackspace_com_dist_img_icon_sharepoint_svg);
             }
         
             .email-wizard {
-                background-image: url('../images/icon-wizard.png');
-                background-image: none, url('../images/icon-wizard.svg');
+                background-image: url($assets_support_rackspace_com_dist_img_icon_wizard_png);
+                background-image: none, url($assets_support_rackspace_com_dist_img_icon_wizard_svg);
                 background-repeat: no-repeat;
                 position: relative;
                 margin-bottom: 20px;
@@ -859,14 +858,14 @@ a {
             font-weight: 400;
             margin-bottom: 20px;
             padding-left: 25px;
-            background: url('../images/icon-plus.svg') 0 3px no-repeat;
+            background: url($assets_support_rackspace_com_dist_img_icon_plus_svg) 0 3px no-repeat;
             
             &:hover{
                 cursor: pointer;
                 color: $color-kcblue;
             }
             
-            &.active {background: url('../images/icon-minus.svg') 0 3px no-repeat}            
+            &.active {background: url($assets_support_rackspace_com_dist_img_icon_minus_svg) 0 3px no-repeat}            
         }
         
         hr {margin-top: 30px;}
@@ -882,7 +881,7 @@ a {
 
 .sidebar {
     min-height: 100%;
-    padding: 75px 20px 30px 0;
+    padding: 35px 20px 30px 0;
     font-family: $font-family-secondary;
     font-size: 14px;
     line-height: 16px;
@@ -949,6 +948,25 @@ a {
             color: $color-kcblue;
         
             &:hover {text-decoration: underline;}
+        }
+    }
+
+    .button-wp {
+        a {
+            display: block;
+            border: 1px solid $color-kcblue;
+            padding: 12px 35px;
+            margin-bottom: 35px;
+            white-space: nowrap;
+            font-weight: 600;
+
+            &:hover {
+                background: $color-kcblue;
+                color: #fff;
+                text-decoration: none;
+            }
+
+            i {margin-right: 10px;}
         }
     }
 }

--- a/config/content.json
+++ b/config/content.json
@@ -42,7 +42,8 @@
         "content": {
             "/": "https://github.com/rackerlabs/docs-support-network/",
             "/launch/": "https://github.com/rackerlabs/docs-support-launch/",
-            "/how-to/": "https://github.com/rackerlabs/rackspace-howto-dev/"
+            "/how-to/": "https://github.com/rackerlabs/rackspace-howto-dev/",
+            "/white-paper/": "https://github.com/rackerlabs/rackspace-howto-dev/"
         },
         "proxy": {
             "/favicon.ico": "https://8d8dcdd952aa2708c2ff-519cda130c91226e76017ae910bdb276.ssl.cf1.rackcdn.com/favicon-aa186bee158ecea4c9b6a98e2ceec3141b6b7d8d94dcb71731ba112e2b17b1db.ico"

--- a/config/routes.json
+++ b/config/routes.json
@@ -84,7 +84,9 @@
         "^/how-to/sharepoint/$": "product.html",
         "^/how-to/.+?-faq/$": "faq.html",
         "^/how-to/.+?-all-articles/$": "page-list.html",
-        "^/how-to/.+?-get-started/$": "getting-started.html"
+        "^/how-to/.+?-get-started/$": "getting-started.html",
+        "^/white-paper/.+?": "white-paper.html",
+        "^/case-study/.+?": "case-study.html"
       }
     }
 }

--- a/templates/support.rackspace.com/_includes/article-header.html
+++ b/templates/support.rackspace.com/_includes/article-header.html
@@ -1,6 +1,8 @@
                         <h2 class="less-margin">{{ title }}</h2>
 
                         <ul class="meta">
+                            {% if created_by %}
                             <li>By: {{ created_by }}</li>
-                            <li>On: {{ created_date }}</li>
+                            {% if created_date %}<li>On: {{ created_date }}</li>{% endif %}
+                            {% endif %}
                         </ul>

--- a/templates/support.rackspace.com/_includes/product-header.html
+++ b/templates/support.rackspace.com/_includes/product-header.html
@@ -1,4 +1,3 @@
-
                         <h2 class="less-margin">{{ title }}</h2>
 
                         <ul class="meta">

--- a/templates/support.rackspace.com/_includes/product-nav.html
+++ b/templates/support.rackspace.com/_includes/product-nav.html
@@ -1,9 +1,9 @@
-<h3>Areas of Interest</h3>
+<h3>Article Types</h3>
 
 {% set productHref = deconst.request.path.replace(r/-faq\/|-get-started\/|-all-articles\/|\/$/, "") %}
 
 <ul class="area">
-  <li{% if deconst.request.path.match(productHref + '/') %} class="active"{% endif %}><a href="{{ productHref }}">Product Guide</a></li>
+  <li{% if deconst.request.path.match('-get-started/') %} class="active"{% endif %}><a href="{{ productHref + "-get-started/" }}">Product Guide</a></li>
   <li{% if deconst.request.path.match('-faq/') %} class="active"{% endif %}><a href="{{ productHref + "-faq/" }}">FAQs</a></li>
   <li{% if deconst.request.path.match('-all-articles/') %} class="active"{% endif %}><a href="{{ productHref + "-all-articles/" }}">All Articles</a></li>
 </ul>

--- a/templates/support.rackspace.com/_includes/whitepaper-sidebar.html
+++ b/templates/support.rackspace.com/_includes/whitepaper-sidebar.html
@@ -1,0 +1,6 @@
+
+{% if deconst.content.envelope.metadata.resource %}
+<p class="button-wp"><a href="{{ deconst.content.envelope.metadata.resource }}"><i class="fa fa-file-text-o"></i>Download Now</a></p>
+{% endif %}
+
+{% include "_includes/feedback-sidebar.html" %}

--- a/templates/support.rackspace.com/_layouts/base.html
+++ b/templates/support.rackspace.com/_layouts/base.html
@@ -2,6 +2,8 @@
 
 {% set title = "Knowledge Center | " + deconst.content.envelope.title %}
 {% set product = deconst.content.envelope.metadata.product %}
+{% set created_by = deconst.content.envelope.metadata.created_by  %}
+{% set created_date = deconst.content.envelope.metadata.created_date  %}
 
 {% set siteUrl = deconst.url.getSiteUrl(deconst.context, deconst.context.request.path) %}
 {% set cssUrl = deconst.assets.assets_support_rackspace_com_dist_css_main_css %}

--- a/templates/support.rackspace.com/white-paper.html
+++ b/templates/support.rackspace.com/white-paper.html
@@ -1,12 +1,11 @@
 {% extends "_layouts/base.html" %}
 
-
 {% block bodyContent %}
         <article>
             <div class="container">
                 <div class="row">
                   <div class="three columns sidebar sticky">
-                    {% include "_includes/article-sidebar.html" %}
+                    {% include "_includes/whitepaper-sidebar.html" %}
                   </div>
                   <div class="nine columns content">
                     {% include "_includes/article-header.html" %}


### PR DESCRIPTION
This was ready once the **resource** to download is included in the metadata. It includes a few other styling fixes that I pulled from kc_migration so we may want to merge now and then work on the index pages / resource link separately as part of the jira.
http://support-dev.ipa.rackspace.com/white-paper/object-rocket-for-mongodb/
