### PR TITLE
Disable Node's TLS verification

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -12,7 +12,7 @@ if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
       echo "Submitting to staging."
       export CONTENT_STORE_URL=https://staging.developer.rackspace.com:9000/
       export CONTENT_STORE_APIKEY=${KEY1}${KEY2}${KEY3}
-      export CONTENT_STORE_TLS_VERIFY="false"
+      export NODE_TLS_REJECT_UNAUTHORIZED=0
       export PUBLISH="true"
       ;;
     *)


### PR DESCRIPTION
Follow-on from #23.

This will make it more difficult to revert.
