### PR TITLE
fix broken link in how-to landing page

### DIFF
--- a/templates/support.rackspace.com/home.html
+++ b/templates/support.rackspace.com/home.html
@@ -187,7 +187,7 @@
                 </div>
                 <div class="four columns">
                     <aside class="cta">
-                        <p class="button"><a href="#" id="guide-button" class="banner-button">Read the User Guide</a></p>
+                        <p class="button"><a href="https://developer.rackspace.com/docs/user-guides/infrastructure/" id="guide-button" class="banner-button">Read the User Guide</a></p>
                     </aside>
                 </div>
             </div>
@@ -197,19 +197,19 @@
         <div class="row content home inactive" id="sdks-display">
             <div class="product-type-sdks">
                 <div class="six columns primary">
-                    <p>Speed up development by leveraging an SDK with the language of your choice. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor ncididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
-                    <a href="#">Link to documentation goes here</a>
+                    <p>Speed up development by leveraging an SDK with the language of your choice.</p>
+                    <a href="https://developer.rackspace.com/docs/">Rackspace Develop Docs</a>
                 </div>
                 <div class="six columns">
                     <ul id="sdk-list">
-                        <a href="#"><li><i class="icon-java-bold"></i>Java</li></a>
-                        <a href="#"><li><i class="icon-nodejs"></i>Node</li></a>
-                        <a href="#"><li><i class="icon-looking"></i>Go</li></a>
-                        <a href="#"><li><i class="icon-shell"></i>CLI</li></a>
-                        <a href="#"><li><i class="icon-ruby"></i>Ruby</li></a>
-                        <a href="#"><li><i class="icon-python"></i>Python</li></a>
-                        <a href="#"><li><i class="icon-mobile-device"></i>.Net</li></a>
-                        <a href="#"><li><i class="icon-php"></i>php</li></a>
+                        <a href="https://developer.rackspace.com/docs/rack-cli/"><li><i class="icon-terminal"></i>CLI</li></a>
+                        <a href="https://developer.rackspace.com/sdks/golang/"><li><i class="icon-gopher"></i>Go</li></a>
+                        <a href="https://developer.rackspace.com/sdks/python/"><li><i class="icon-python"></i>Python</li></a>
+                        <a href="https://developer.rackspace.com/sdks/dot-net/"><li><i class="icon-dot-net"></i>.NET</li></a>
+                        <a href="https://developer.rackspace.com/sdks/java/"><li><i class="icon-java"></i>Java</li></a>
+                        <a href="https://developer.rackspace.com/sdks/php/"><li><i class="icon-php"></i>PHP</li></a>
+                        <a href="https://developer.rackspace.com/sdks/node-js/"><li><i class="icon-js"></i>Node.js</li></a>
+                        <a href="https://developer.rackspace.com/sdks/ruby/"><li><i class="icon-ruby"></i>Ruby</li></a>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
Fixes SSDEV-471: landing page has a broken link (user guide)

I also searched the home page for any other link place-holders, and found there's a whole SDK section that's marked inactive.  I filled those in too, and removed some of the boiler plate lorem ipsum stuff, since it will be sent to the customers browser, although hidden from view.
