### PR TITLE
add <hr> to article sitebar after product nav

### DIFF
--- a/templates/support.rackspace.com/_includes/article-sidebar.html
+++ b/templates/support.rackspace.com/_includes/article-sidebar.html
@@ -1,6 +1,8 @@
 
 {% include "_includes/product-nav.html" %}
 
+<hr />
+
                         {#
                          # SSDEV-456 removed until operational
 


### PR DESCRIPTION
@jonstovall noticed we don't have a <hr> after our product nav when viewing articles.

Adding it to the page.
